### PR TITLE
Supporting new JPA methods: deleteAllById, deleteAllByIdInBatch, findBy & getReferenceById

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.5</version>
         <relativePath/>
     </parent>
 
@@ -22,9 +22,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.surefire.plugin.version>3.0.0-M7</maven.surefire.plugin.version>
-        <test-container-postgres>1.17.3</test-container-postgres>
+        <test-container-postgres>1.17.5</test-container-postgres>
         <apache-collections>4.4</apache-collections>
-        <jpa-model-gen>5.6.10.Final</jpa-model-gen>
+        <jpa-model-gen>5.6.14.Final</jpa-model-gen>
     </properties>
 
     <dependencies>

--- a/readme.md
+++ b/readme.md
@@ -92,11 +92,11 @@ Explanation of the command:
 > Now we will start the postgres image as in its own container together with the previous created data volume container.
 
 ```bash
-docker run --name inventory-postgreSQL-dev -p 5432:5432 -e POSTGRES_PASSWORD=inventory-docker-test-password -e POSTGRES_INITDB_ARGS="--data-checksums" -d --volumes-from inventory-postgres-data-dev postgres:13-alpine
+docker run --name inventory-postgreSQL-dev -p 5432:5432 -e POSTGRES_PASSWORD=inventory-docker-test-password -e POSTGRES_INITDB_ARGS="--data-checksums" -d --volumes-from inventory-postgres-data-dev postgres:14-alpine
 ```
 
 Explanation of the command:  
-* Create and start a new container from the postgres:13-alpine image.   
+* Create and start a new container from the postgres:14-alpine image.   
 * For this container, we are providing the name: `inventory-postgreSQL-dev`
 * Start the database on port `5432` internally and expose it through the same port.
 * We are providing parameters (-e) to the database like:  
@@ -119,7 +119,7 @@ That's it! You can now properly run the application without any issues.
 To access the postgres through command line, the following command can help you with that:
      
 ```bash
-docker run -it --link inventory-postgreSQL-dev:postgres --rm postgres:13-alpine sh -c 'exec psql -h "$POSTGRES_PORT_5432_TCP_ADDR" -p "$POSTGRES_PORT_5432_TCP_PORT" -U postgres'
+docker run -it --link inventory-postgreSQL-dev:postgres --rm postgres:14-alpine sh -c 'exec psql -h "$POSTGRES_PORT_5432_TCP_ADDR" -p "$POSTGRES_PORT_5432_TCP_PORT" -U postgres'
 ```
 
 This will ask for the password which can be found in [Application.yml](/src/main/resources/application.yml) -> datasource password  

--- a/src/main/java/com/github/mdevloo/multi/tenancy/fwk/multitenancy/MultiTenancyRepository.java
+++ b/src/main/java/com/github/mdevloo/multi/tenancy/fwk/multitenancy/MultiTenancyRepository.java
@@ -26,7 +26,7 @@ public class MultiTenancyRepository<T, I> extends SimpleJpaRepository<T, I> {
 
   @Override
   public Optional<T> findById(@NonNull final I id) {
-    final Class<T> entityType = this.entityInformation.getJavaType();
+    final Class<T> entityType = this.getDomainClass();
     Objects.requireNonNull(id, "ID can not be null for Type [" + entityType + "]");
 
     final CriteriaBuilder criteriaBuilder = this.entityManager.getCriteriaBuilder();
@@ -41,20 +41,35 @@ public class MultiTenancyRepository<T, I> extends SimpleJpaRepository<T, I> {
     return q.getResultStream().findFirst();
   }
 
-  /**
-   * GetOne is not multi tenant compliant by default as it returns a lazy fetched proxy of the entity.
-   * When executing a getter method, the data is fetched from the database without passing the hibernate filter!
-   * JPA allows us to throw EntityNotFoundException and that is exactly what we do here to avoid security holes.
-   */
+  @Deprecated
   @Override
   public T getOne(@NonNull final I i) {
-    throw new EntityNotFoundException();
+    return this.getReferenceById(i);
+  }
+
+  @Override
+  @Deprecated
+  public T getById(@NonNull final I i) {
+    return this.getReferenceById(i);
+  }
+
+  /**
+   * getReferenceById is not multi tenant compliant by default as it returns a lazy fetched proxy of the
+   * entity. When executing a getter method, the data is fetched from the database without passing
+   * the hibernate filter! JPA allows us to throw EntityNotFoundException and that is exactly what
+   * we do here to avoid security holes.
+   *
+   * @since Spring boot 2.7.5 added
+   */
+  @Override
+  public T getReferenceById(@NonNull final I i) {
+    throw new EntityNotFoundException("Lazy fetching is not supported as it breaks multi tenancy");
   }
 
   @Override
   public void delete(@NonNull final T entity) {
     Objects.requireNonNull(
-        entity, "Entity can not be null for Object [" + this.entityInformation.getJavaType() + "]");
+        entity, "Entity can not be null for Object [" + this.getDomainClass() + "]");
 
     if (this.entityInformation.isNew(entity)
         || this.findById(this.entityInformation.getRequiredId(entity)).isEmpty()) {

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,7 +1,7 @@
 spring:
   datasource:
     driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
-    url: jdbc:tc:postgresql:13:///inventory
+    url: jdbc:tc:postgresql:14:///inventory
     username: postgres
     password: test
   jpa:


### PR DESCRIPTION
Supporting new JPA methods: deleteAllById, deleteAllByIdInBatch, findBy (/w FetchableFluentQuery) & getReferenceById including tests.

Deprecating the methods getById & getOne due to following guidelines of SimpleJpaRepository.

Upgrading to Postgres 14, Spring boot 2.7.5 & it's dependencies.

No breaking changes with older versions as they are all still compliant (new JPA methods were multi tenancy compliant by default except getReferenceById)