### PR TITLE
Feature/spring boot 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,27 +5,39 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.5</version>
+        <version>3.0.6</version>
         <relativePath/>
     </parent>
 
     <groupId>com.github.mdevloo</groupId>
     <artifactId>spring-discriminator-based-multitenancy-with-auth0</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
     <name>spring-discriminator-based-multitenancy-with-auth0</name>
     <description>SaaS Discriminator based Multi Tenancy with JPA, Hibernate, Spring MVC and Auth0 as
         identity provider.
     </description>
 
     <properties>
-        <java.version>11</java.version>
+        <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.surefire.plugin.version>3.0.0-M7</maven.surefire.plugin.version>
-        <test-container-postgres>1.17.5</test-container-postgres>
+        <test-container-postgres>1.17.6</test-container-postgres>
         <apache-collections>4.4</apache-collections>
-        <jpa-model-gen>5.6.14.Final</jpa-model-gen>
+        <jpa-model-gen>6.2.2.Final</jpa-model-gen>
+        <jakara-xml-binding-for-jpa-model-gen>4.0.0</jakara-xml-binding-for-jpa-model-gen>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>${test-container-postgres}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -73,6 +85,11 @@
             <artifactId>flyway-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>${jakara-xml-binding-for-jpa-model-gen}</version>
+        </dependency>
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>
@@ -84,7 +101,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.orm</groupId>
             <artifactId>hibernate-jpamodelgen</artifactId>
             <version>${jpa-model-gen}</version>
             <scope>provided</scope>
@@ -108,19 +125,16 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>${test-container-postgres}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>${test-container-postgres}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
-            <version>${test-container-postgres}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -136,14 +150,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${maven.surefire.plugin.version}</version>
-            </plugin>
-            <plugin>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <version>${maven.surefire.plugin.version}</version>
             </plugin>
         </plugins>
     </build>

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,20 @@ Inventory is a production ready Spring Boot application on how to correctly setu
 * Integrated with Auth0 identity provider which automatically resolves the tenant id by using the received JWT token.
 * Fully tested E2E with focus on security & the multi tenancy implementation.
 
+## Branches
+
+> master
+
+The `master` branch is the stable branch targeting Spring boot 3.
+
+> release/spring-boot-v2
+
+The `release/spring-boot-v2` branch is the stable branch targeting Spring boot 2.
+
+> feature/X
+
+Feature branches are development branches which should be used in production environments.
+
 ## Detailed explanation
 
 There are 3 types of Multi Tenancy.
@@ -68,7 +82,7 @@ This concludes the documentation for the multi tenancy part.
 
 ## Startup of the application
 
-- JVM version should be Java 11 (or higher)
+- JVM version should be Java 17 (or higher)
 - Docker is necessary to be able to run the tests through TestContainer + local development thanks to the prepared docker commands below.
 
 ### Initial Database setup

--- a/src/main/java/com/github/mdevloo/multi/tenancy/core/inventory/domain/inventory/Inventory.java
+++ b/src/main/java/com/github/mdevloo/multi/tenancy/core/inventory/domain/inventory/Inventory.java
@@ -8,14 +8,14 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.GenericGenerator;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import java.util.UUID;
 
 @Entity

--- a/src/main/java/com/github/mdevloo/multi/tenancy/core/inventory/domain/vendor/Vendor.java
+++ b/src/main/java/com/github/mdevloo/multi/tenancy/core/inventory/domain/vendor/Vendor.java
@@ -8,13 +8,13 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.GenericGenerator;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.OneToMany;
-import javax.persistence.Table;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import java.util.List;
 import java.util.UUID;
 

--- a/src/main/java/com/github/mdevloo/multi/tenancy/core/web/inventory/CreateInventoryRequestDTO.java
+++ b/src/main/java/com/github/mdevloo/multi/tenancy/core/web/inventory/CreateInventoryRequestDTO.java
@@ -2,8 +2,8 @@ package com.github.mdevloo.multi.tenancy.core.web.inventory;
 
 import lombok.Data;
 
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 
 @Data
 class CreateInventoryRequestDTO {

--- a/src/main/java/com/github/mdevloo/multi/tenancy/core/web/inventory/InventoryController.java
+++ b/src/main/java/com/github/mdevloo/multi/tenancy/core/web/inventory/InventoryController.java
@@ -9,7 +9,6 @@ import com.github.mdevloo.multi.tenancy.core.inventory.usecase.inventory.GetAllI
 import com.github.mdevloo.multi.tenancy.core.inventory.usecase.inventory.InventoryCreationRequest;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/github/mdevloo/multi/tenancy/core/web/inventory/InventoryController.java
+++ b/src/main/java/com/github/mdevloo/multi/tenancy/core/web/inventory/InventoryController.java
@@ -10,8 +10,8 @@ import com.github.mdevloo.multi.tenancy.core.inventory.usecase.inventory.Invento
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.validation.annotation.Validated;
@@ -42,7 +42,7 @@ public class InventoryController {
   public List<InventoryDTO> getAllInventory() {
     return this.getAllInventory.execute().stream()
         .map(this.inventoryConverter::convert)
-        .collect(Collectors.toUnmodifiableList());
+        .toList();
   }
 
   @PostMapping(path = "/create")

--- a/src/main/java/com/github/mdevloo/multi/tenancy/fwk/auth0/security/SecurityConfig.java
+++ b/src/main/java/com/github/mdevloo/multi/tenancy/fwk/auth0/security/SecurityConfig.java
@@ -2,9 +2,9 @@ package com.github.mdevloo.multi.tenancy.fwk.auth0.security;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.annotation.web.configurers.oauth2.server.resource.OAuth2ResourceServerConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
@@ -14,13 +14,21 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtDecoders;
 import org.springframework.security.oauth2.jwt.JwtValidators;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.List;
 
 import static com.github.mdevloo.multi.tenancy.core.AppConstants.API;
 
 @EnableWebSecurity
-public class SecurityConfig extends WebSecurityConfigurerAdapter {
+@Configuration
+public class SecurityConfig {
 
   private final String audience;
   private final String issuer;
@@ -32,8 +40,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     this.issuer = issuer;
   }
 
-  @Override
-  public void configure(final HttpSecurity http) throws Exception {
+  @Bean
+  public SecurityFilterChain configure(final HttpSecurity http) throws Exception {
+    http.cors();
     http.csrf().csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse());
     http.headers()
         .referrerPolicy(
@@ -41,17 +50,29 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 referrerPolicyConfig.policy(ReferrerPolicyHeaderWriter.ReferrerPolicy.SAME_ORIGIN));
 
     http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
-    http.authorizeRequests()
-        .mvcMatchers(API + "/**")
+    http.authorizeHttpRequests()
+        .requestMatchers(API + "/**")
         .authenticated()
         .and()
         .oauth2ResourceServer(OAuth2ResourceServerConfigurer::jwt);
+    return http.build();
+  }
+
+  @Bean
+  CorsConfigurationSource corsConfigurationSource() {
+    CorsConfiguration configuration = new CorsConfiguration();
+    configuration.addAllowedHeader("*");
+    configuration.setAllowedOrigins(
+        List.of()); /* Add Origin here for frontend: localhost:4200 for example */
+    configuration.setAllowedMethods(Arrays.asList("OPTIONS", "HEAD", "GET", "POST", "DELETE"));
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", configuration);
+    return source;
   }
 
   @Bean
   JwtDecoder jwtDecoder() {
-    final NimbusJwtDecoder nimbusJwtDecoder =
-        (NimbusJwtDecoder) JwtDecoders.fromOidcIssuerLocation(this.issuer);
+    final NimbusJwtDecoder nimbusJwtDecoder = JwtDecoders.fromOidcIssuerLocation(this.issuer);
     final OAuth2TokenValidator<Jwt> audienceValidator = new AudienceValidator(this.audience);
     final OAuth2TokenValidator<Jwt> withIssuer = JwtValidators.createDefaultWithIssuer(this.issuer);
     final OAuth2TokenValidator<Jwt> withAudience =

--- a/src/main/java/com/github/mdevloo/multi/tenancy/fwk/multitenancy/HibernateInterceptorConfiguration.java
+++ b/src/main/java/com/github/mdevloo/multi/tenancy/fwk/multitenancy/HibernateInterceptorConfiguration.java
@@ -1,17 +1,16 @@
 package com.github.mdevloo.multi.tenancy.fwk.multitenancy;
 
+import java.util.Map;
 import lombok.AllArgsConstructor;
-import org.hibernate.EmptyInterceptor;
+import org.hibernate.Interceptor;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
 import org.springframework.stereotype.Component;
-
-import java.util.Map;
 
 @Component
 @AllArgsConstructor
 public class HibernateInterceptorConfiguration implements HibernatePropertiesCustomizer {
 
-  private final EmptyInterceptor tenantInterceptor;
+  private final Interceptor tenantInterceptor;
 
   @Override
   public void customize(final Map<String, Object> hibernateProperties) {

--- a/src/main/java/com/github/mdevloo/multi/tenancy/fwk/multitenancy/HibernateMultiTenancyInterceptorBean.java
+++ b/src/main/java/com/github/mdevloo/multi/tenancy/fwk/multitenancy/HibernateMultiTenancyInterceptorBean.java
@@ -1,6 +1,6 @@
 package com.github.mdevloo.multi.tenancy.fwk.multitenancy;
 
-import org.hibernate.EmptyInterceptor;
+import org.hibernate.Interceptor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Configuration;
 public class HibernateMultiTenancyInterceptorBean {
 
   @Bean
-  public EmptyInterceptor hibernateTenantInterceptor() {
+  public Interceptor hibernateTenantInterceptor() {
     return new TenantInterceptor();
   }
 }

--- a/src/main/java/com/github/mdevloo/multi/tenancy/fwk/multitenancy/MultiTenancyRepository.java
+++ b/src/main/java/com/github/mdevloo/multi/tenancy/fwk/multitenancy/MultiTenancyRepository.java
@@ -4,11 +4,11 @@ import org.springframework.data.jpa.repository.support.JpaEntityInformation;
 import org.springframework.data.jpa.repository.support.SimpleJpaRepository;
 import org.springframework.lang.NonNull;
 
-import javax.persistence.EntityManager;
-import javax.persistence.EntityNotFoundException;
-import javax.persistence.TypedQuery;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.persistence.TypedQuery;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
 import java.util.Objects;
 import java.util.Optional;
 

--- a/src/main/java/com/github/mdevloo/multi/tenancy/fwk/multitenancy/TenantEntity.java
+++ b/src/main/java/com/github/mdevloo/multi/tenancy/fwk/multitenancy/TenantEntity.java
@@ -7,8 +7,8 @@ import org.hibernate.annotations.Filter;
 import org.hibernate.annotations.FilterDef;
 import org.hibernate.annotations.ParamDef;
 
-import javax.persistence.Column;
-import javax.persistence.MappedSuperclass;
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
 
 @RequiredArgsConstructor
 @Getter
@@ -16,7 +16,7 @@ import javax.persistence.MappedSuperclass;
 @MappedSuperclass()
 @FilterDef(
     name = TenantEntity.TENANT_FILTER_NAME,
-    parameters = @ParamDef(name = TenantEntity.TENANT_FILTER_ARGUMENT_NAME, type = "string"),
+    parameters = @ParamDef(name = TenantEntity.TENANT_FILTER_ARGUMENT_NAME, type = String.class),
     defaultCondition =
         TenantEntity.TENANT_ID_PROPERTY_NAME + "= :" + TenantEntity.TENANT_FILTER_ARGUMENT_NAME)
 @Filter(name = TenantEntity.TENANT_FILTER_NAME)

--- a/src/main/java/com/github/mdevloo/multi/tenancy/fwk/multitenancy/TenantInterceptor.java
+++ b/src/main/java/com/github/mdevloo/multi/tenancy/fwk/multitenancy/TenantInterceptor.java
@@ -1,13 +1,12 @@
 package com.github.mdevloo.multi.tenancy.fwk.multitenancy;
 
-import org.hibernate.EmptyInterceptor;
-import org.hibernate.type.Type;
-
-import java.io.Serializable;
-
 import static com.github.mdevloo.multi.tenancy.fwk.multitenancy.TenantEntity.TENANT_FILTER_ARGUMENT_NAME;
 
-public final class TenantInterceptor extends EmptyInterceptor {
+import java.io.Serializable;
+import org.hibernate.Interceptor;
+import org.hibernate.type.Type;
+
+public final class TenantInterceptor implements Interceptor {
 
   @Override
   public boolean onSave(

--- a/src/main/java/com/github/mdevloo/multi/tenancy/fwk/multitenancy/TenantServiceAspect.java
+++ b/src/main/java/com/github/mdevloo/multi/tenancy/fwk/multitenancy/TenantServiceAspect.java
@@ -9,8 +9,8 @@ import org.hibernate.Filter;
 import org.hibernate.Session;
 import org.springframework.stereotype.Component;
 
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 
 import static com.github.mdevloo.multi.tenancy.fwk.multitenancy.TenantEntity.TENANT_FILTER_ARGUMENT_NAME;
 import static com.github.mdevloo.multi.tenancy.fwk.multitenancy.TenantEntity.TENANT_FILTER_NAME;

--- a/src/test/java/com/github/mdevloo/multi/tenancy/core/inventory/domain/inventory/InventoryRepositoryTest.java
+++ b/src/test/java/com/github/mdevloo/multi/tenancy/core/inventory/domain/inventory/InventoryRepositoryTest.java
@@ -51,9 +51,13 @@ class InventoryRepositoryTest extends AbstractIntegrationTest {
   @Transactional
   @Test
   void deleteById() {
-    final UUID otherTenantId = UUID.fromString("ea05d535-a53a-4a30-a8e6-9ede533d25c6");
-    Assertions.assertThatExceptionOfType(EmptyResultDataAccessException.class)
-        .isThrownBy(() -> this.inventoryRepository.deleteById(otherTenantId));
+    this.inventoryRepository.deleteById(UUID.fromString("ea05d535-a53a-4a30-a8e6-9ede533d25c6"));
+
+    this.mockSecurityContext("auth0|88b53f66-6d1e-48b2-a0d2-8444953b202e");
+    Assertions.assertThat(
+            this.inventoryRepository.existsById(
+                UUID.fromString("ea05d535-a53a-4a30-a8e6-9ede533d25c6")))
+        .isTrue();
   }
 
   @Transactional
@@ -66,11 +70,8 @@ class InventoryRepositoryTest extends AbstractIntegrationTest {
 
     this.mockSecurityContext("auth0|99b53f66-6d1e-48b2-a0d2-8444953b202e");
     Assertions.assertThat(this.inventoryRepository.count()).isEqualTo(2L);
-    Assertions.assertThatExceptionOfType(EmptyResultDataAccessException.class)
-        .isThrownBy(
-            () ->
-                this.inventoryRepository.deleteAllById(
-                    List.of(UUID.fromString("ba05d535-a53a-4a30-a8e6-9ede533d25c5"))));
+    this.inventoryRepository.deleteAllById(
+        List.of(UUID.fromString("ba05d535-a53a-4a30-a8e6-9ede533d25c5")));
 
     this.mockSecurityContext("auth0|55b53f66-6d1e-48b2-a0d2-8444953b202e");
     Assertions.assertThat(

--- a/src/test/java/com/github/mdevloo/multi/tenancy/core/inventory/domain/inventory/InventoryRepositoryTest.java
+++ b/src/test/java/com/github/mdevloo/multi/tenancy/core/inventory/domain/inventory/InventoryRepositoryTest.java
@@ -9,7 +9,6 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.data.domain.Example;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/src/test/java/com/github/mdevloo/multi/tenancy/core/web/inventory/InventoryControllerIntegrationTest.java
+++ b/src/test/java/com/github/mdevloo/multi/tenancy/core/web/inventory/InventoryControllerIntegrationTest.java
@@ -2,6 +2,7 @@ package com.github.mdevloo.multi.tenancy.core.web.inventory;
 
 import com.github.mdevloo.multi.tenancy.core.AbstractMockMvcTest;
 import com.github.mdevloo.multi.tenancy.fwk.ObjectNotFoundException;
+import jakarta.servlet.ServletException;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -10,7 +11,6 @@ import org.springframework.test.context.jdbc.SqlGroup;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
-import org.springframework.web.util.NestedServletException;
 
 import java.util.Collections;
 
@@ -47,7 +47,7 @@ class InventoryControllerIntegrationTest extends AbstractMockMvcTest {
 
   @Test
   void getInventoryUnknownId() {
-    Assertions.assertThatExceptionOfType(NestedServletException.class)
+    Assertions.assertThatExceptionOfType(ServletException.class)
         .isThrownBy(
             () ->
                 this.getMockMvc()


### PR DESCRIPTION
Supporting Spring boot 3

- Adding additional dependency `jakarta.xml.bind-api` which is only necessary for the JPA Model Gen library since V6.X
- Minimum Java version is now 17 due to Spring boot 3.
- Adding CORS configuration
- Replacing deprecated EmptyInterceptor with TenantInterceptor interface.

Since hibernate 6, the `TenantInterceptor` interface had some of it's methods deprecated which we still depend on.
For now, these are still required but can perhaps be replaced later on by using the `@TenantId` annotation. Time will tell.